### PR TITLE
Fix jump detection bug, #57

### DIFF
--- a/2Dgame/Assets/Scripts/PlatformScript.cs
+++ b/2Dgame/Assets/Scripts/PlatformScript.cs
@@ -29,8 +29,10 @@ public class PlatformScript : MonoBehaviour {
     protected void OnCollisionEnter2D(Collision2D collision)
     {
         Rigidbody2D rb = collision.rigidbody;
+		float playerHalf = rb.transform.localScale.x / 2;
+		float dist = (rb.position.y - playerHalf) - this.transform.position.y;
 
-        if (rb.velocity.y <= 0)
+		if (rb.velocity.y <= 0 && dist >= 0)
         {
             rb.velocity = new Vector2(rb.velocity.x, jumpSpeed);
             audioSource.Play();


### PR DESCRIPTION
Fix to bug described in #57 by adding the check that the player's y-pos has to be greater than the platform's.