### PR TITLE
Lower difficulty

### DIFF
--- a/2Dgame/Assets/Scripts/CameraScript.cs
+++ b/2Dgame/Assets/Scripts/CameraScript.cs
@@ -4,7 +4,7 @@ using UnityEngine;
 
 public class CameraScript : MonoBehaviour {
 
-	float standardSpeed = 5.4f;
+	float standardSpeed;
 	float scrollSpeed;
 
 	public Rigidbody2D target;
@@ -23,12 +23,43 @@ public class CameraScript : MonoBehaviour {
 	 * Uses linear interpolation to make this switch in speed feel smooth.
 	 */
 	void ScrollUp() {
-		transform.position = new Vector3 (transform.position.x, transform.position.y + scrollSpeed*Time.deltaTime, transform.position.z);
+        StandardSpeed();
 
-		if (target.position.y - transform.position.y > 5f) {
-			scrollSpeed = Mathf.Lerp (scrollSpeed, target.velocity.y, 0.1f);
-		} else {
-			scrollSpeed = Mathf.Lerp(scrollSpeed, standardSpeed, 2f);
-		}
+        if (target.position.y - transform.position.y > 3f)
+        {
+            scrollSpeed = Mathf.Lerp(scrollSpeed, target.velocity.y, LerpSpeed());
+        }
+        else
+        {
+            scrollSpeed = Mathf.Lerp(scrollSpeed, standardSpeed, LerpSpeed());
+        }
+
+        transform.position = new Vector3 (transform.position.x, transform.position.y + scrollSpeed * Time.deltaTime, transform.position.z);
 	}
+
+    /**
+     * Scrolls up in different speeds, depending on score.
+     * To make the start easier.
+     */
+    void StandardSpeed()
+    {
+        if (transform.position.y < 200)
+        {
+            standardSpeed = 2f;
+        }
+        else if (transform.position.y < 500)
+        {
+            standardSpeed = 4f;
+        }
+        else
+        {
+            standardSpeed = 5.4f;
+        }
+    }
+
+    float LerpSpeed()
+    {
+        float distance = Mathf.Abs(target.position.y - transform.position.y);
+        return (distance / 100) * 0.1f * distance;
+    }
 }

--- a/2Dgame/Assets/Scripts/CameraScript.cs
+++ b/2Dgame/Assets/Scripts/CameraScript.cs
@@ -57,6 +57,9 @@ public class CameraScript : MonoBehaviour {
         }
     }
 
+    /**
+     * Lerps faster the farther away from the middle the player is.
+     */
     float LerpSpeed()
     {
         float distance = Mathf.Abs(target.position.y - transform.position.y);

--- a/2Dgame/Assets/Scripts/PlatformSpawnerScript.cs
+++ b/2Dgame/Assets/Scripts/PlatformSpawnerScript.cs
@@ -145,16 +145,10 @@ public class PlatformSpawnerScript : MonoBehaviour {
      */
     void SpawnSecond(GameObject platform, float yPosition)
     {
-        if (Random.Range(0, 100) < 60)
+        if (Camera.main.transform.position.y < 500 && (platform.Equals(platformPrefabs[0]) || platform.Equals(platformPrefabs[2])) && Random.Range(0, 100) < 60)
         {
-            if (platform.Equals(platformPrefabs[0]) || platform.Equals(platformPrefabs[2]))
-            {
-                if (Camera.main.transform.position.y < 500)
-                {
-                    Vector2 pos = new Vector2(Xvalue(lastXPos), yPosition);
-                    Instantiate(platformPrefabs[0], pos, Quaternion.identity);
-                }
-            }
+            Vector2 pos = new Vector2(Xvalue(lastXPos), yPosition);
+            Instantiate(platformPrefabs[0], pos, Quaternion.identity);
         }
     }
 

--- a/2Dgame/Assets/Scripts/PlatformSpawnerScript.cs
+++ b/2Dgame/Assets/Scripts/PlatformSpawnerScript.cs
@@ -129,9 +129,9 @@ public class PlatformSpawnerScript : MonoBehaviour {
 	 * in a row less likely, though not impossible
 	 */
 	int correctX() {
-        int x = Random.Range(-6, 7);
+        int x = 2 * Random.Range(-3, 4);
 		if (x == lastXPos) {
-            x = Random.Range(-6, 7);
+            x = 2 * Random.Range(-3, 4);
 		}
 		lastXPos = x;
 		return x;
@@ -141,11 +141,14 @@ public class PlatformSpawnerScript : MonoBehaviour {
      * Spawns a second platform at the same yPostion if 
      * all the criterias are met.
      * 
-     * Currently 60 percent chance to spawn a second one.
+     * Chance to spawn a second one decreases with score
      */
     void SpawnSecond(GameObject platform, float yPosition)
     {
-        if (Camera.main.transform.position.y < 500 && (platform.Equals(platformPrefabs[0]) || platform.Equals(platformPrefabs[2])) && Random.Range(0, 100) < 60)
+        float yPos = Camera.main.transform.position.y;
+        int chance = yPos < 250 ? 60 : 30;
+
+        if (yPos < 400 && (platform.Equals(platformPrefabs[0]) || platform.Equals(platformPrefabs[2])) && Random.Range(0, 100) < chance)
         {
             Vector2 pos = new Vector2(Xvalue(lastXPos), yPosition);
             Instantiate(platformPrefabs[0], pos, Quaternion.identity);
@@ -158,11 +161,11 @@ public class PlatformSpawnerScript : MonoBehaviour {
      */
     int Xvalue(int otherX)
     {
-        if (otherX - 6 < -6)
+        if (otherX < 0)
         {
-            return Random.Range(otherX + 6, 7);
+            return 2 * Random.Range(otherX / 2 + 3, 4);
         }
 
-        return Random.Range(-6, otherX - 6);
+        return 2 * Random.Range(-3, otherX / 2 - 2);
     }
 }

--- a/2Dgame/Assets/Scripts/PlatformSpawnerScript.cs
+++ b/2Dgame/Assets/Scripts/PlatformSpawnerScript.cs
@@ -123,7 +123,7 @@ public class PlatformSpawnerScript : MonoBehaviour {
 
 	/**
 	 * Returns a random x-position to spawn a platform at.
-	 * Makes two platforms in the same position twice in a row
+	 * Makes two platforms in the same position twice
 	 * in a row less likely, though not impossible
 	 */
 	int correctX() {

--- a/2Dgame/Assets/Scripts/PlatformSpawnerScript.cs
+++ b/2Dgame/Assets/Scripts/PlatformSpawnerScript.cs
@@ -5,7 +5,7 @@ using UnityEngine;
 public class PlatformSpawnerScript : MonoBehaviour {
 
 	float yPosAtLastSpawn = 5f;
-	float lastXPos = 0;
+	int lastXPos = 0;
     Queue prefabqueue;
 
     public float distanceBetween = 3.2f;
@@ -38,9 +38,15 @@ public class PlatformSpawnerScript : MonoBehaviour {
             choosePlatform();
         }
         GameObject platformType = (GameObject) prefabqueue.Dequeue();
-		Vector2 pos = new Vector2(correctX(), yPosAtLastSpawn + distanceBetween + 15f);
+        float yPos = yPosAtLastSpawn + distanceBetween + 15f;
+        Vector2 pos = new Vector2(correctX(), yPos);
         GameObject go = Instantiate(platformType, pos, Quaternion.identity);
-		go.transform.parent = platformParent;
+        go.transform.parent = platformParent;
+
+        if (Random.Range(0, 100) < 40)
+        {
+            SpawnSecond(platformType, yPos);
+        }
 	}
 
 	/**
@@ -134,4 +140,32 @@ public class PlatformSpawnerScript : MonoBehaviour {
 		lastXPos = x;
 		return x;
 	}
+
+    /**
+     * Spawns a second platform at the same yPostion if 
+     * all the criterias are met.
+     */
+    void SpawnSecond(GameObject platform, float yPosition)
+    {
+        if (platform.Equals(platformPrefabs[0]) || platform.Equals(platformPrefabs[2]))
+        {
+            if (Camera.main.transform.position.y < 500)
+            {
+                Vector2 pos = new Vector2(XValue(lastXPos), yPosition);
+                Instantiate(platformPrefabs[0], pos, Quaternion.identity);
+            }
+        }
+    }
+
+
+    int XValue(int otherX)
+    {
+        int x = correctX();
+        while (x >= otherX - 4 && x <= otherX + 4)
+        {
+            x = correctX();
+        }
+
+        return x;
+    }
 }

--- a/2Dgame/Assets/Scripts/PlatformSpawnerScript.cs
+++ b/2Dgame/Assets/Scripts/PlatformSpawnerScript.cs
@@ -42,11 +42,7 @@ public class PlatformSpawnerScript : MonoBehaviour {
         Vector2 pos = new Vector2(correctX(), yPos);
         GameObject go = Instantiate(platformType, pos, Quaternion.identity);
         go.transform.parent = platformParent;
-
-        if (Random.Range(0, 100) < 40)
-        {
-            SpawnSecond(platformType, yPos);
-        }
+        SpawnSecond(platformType, yPos);
 	}
 
 	/**
@@ -133,9 +129,9 @@ public class PlatformSpawnerScript : MonoBehaviour {
 	 * in a row less likely, though not impossible
 	 */
 	int correctX() {
-		int x = 2 * Random.Range (-3, 4);
+        int x = Random.Range(-6, 7);
 		if (x == lastXPos) {
-			x = 2 * Random.Range (-3, 4);
+            x = Random.Range(-6, 7);
 		}
 		lastXPos = x;
 		return x;
@@ -144,28 +140,35 @@ public class PlatformSpawnerScript : MonoBehaviour {
     /**
      * Spawns a second platform at the same yPostion if 
      * all the criterias are met.
+     * 
+     * Currently 60 percent chance to spawn a second one.
      */
     void SpawnSecond(GameObject platform, float yPosition)
     {
-        if (platform.Equals(platformPrefabs[0]) || platform.Equals(platformPrefabs[2]))
+        if (Random.Range(0, 100) < 60)
         {
-            if (Camera.main.transform.position.y < 500)
+            if (platform.Equals(platformPrefabs[0]) || platform.Equals(platformPrefabs[2]))
             {
-                Vector2 pos = new Vector2(XValue(lastXPos), yPosition);
-                Instantiate(platformPrefabs[0], pos, Quaternion.identity);
+                if (Camera.main.transform.position.y < 500)
+                {
+                    Vector2 pos = new Vector2(Xvalue(lastXPos), yPosition);
+                    Instantiate(platformPrefabs[0], pos, Quaternion.identity);
+                }
             }
         }
     }
 
-
-    int XValue(int otherX)
+    /**
+     * Sets the spawnposition for the other platform.
+     * There is always at least two world units between them.
+     */
+    int Xvalue(int otherX)
     {
-        int x = correctX();
-        while (x >= otherX - 4 && x <= otherX + 4)
+        if (otherX - 6 < -6)
         {
-            x = correctX();
+            return Random.Range(otherX + 6, 7);
         }
 
-        return x;
+        return Random.Range(-6, otherX - 6);
     }
 }

--- a/2Dgame/Assets/Scripts/PlayerScript.cs
+++ b/2Dgame/Assets/Scripts/PlayerScript.cs
@@ -45,7 +45,7 @@ public class PlayerScript : MonoBehaviour {
 		#endif
 
 		float flipped = (GameControllerScript.straight == false) ? -1 : 1;
-		rb.velocity = new Vector2 (flipped * h * horizontalSpeed,rb.velocity.y);
+		rb.velocity = new Vector2 (flipped * h * horizontalSpeed, rb.velocity.y);
 	}
 
     /**


### PR DESCRIPTION
I now think this feels good enough to warrant a pull req. So:

* Spawn a second platform on the same y-position if
  * We are at 500 or lower
  * A normal or a trampoline platform has been spawned

If these criteria are met, there is a 60 percent chance to spawn a second platform.

This commit also lowers the scroll speed at the start of the game, and increases this gradually to what we have now. in making this change, the camerafollow became very jumpy if you were faster than the scroll speed, so I changed how the camera follows the player:

* Baseline lerpspeed is lowered (to reduce jumpyness)
* Lerpspeed increases the further away the player is from the center (to always keep the player on the screen)

I think this feels kinda good, what do you think?

#97 
